### PR TITLE
Dalil component fix

### DIFF
--- a/src/contents/chapter1.js
+++ b/src/contents/chapter1.js
@@ -9,7 +9,7 @@ export default class Chapter1 extends React.Component {
   render() {
     return (
       <View style={{ flex: 1 }}>
-        <Dalil ayat='Testing' soundFile='test.mp3' />
+        <Dalil ayat='Testing' soundFile={require('./dalil-sound/test.mp3')} />
         <Paragraph>
           Kebutuhan manusia terhadap Tuhan itu bersifat permanen dan tidak akan hilang, artinya kapan pun dan di mana pun manusia hidup pasti membutuhkan Tuhan.
           Dalam kondisi tertentu manusia mengabaikan atau mengeyampingkan kebutuhan ini. Namun hal ini hanya sementara dikarenakan pada akhirnya kebutuhan akan Tuhan akan tetap muncul pada saat manusia mengalami persoalan hidup berat atau kehidupannnya terancam.

--- a/src/dalil/README.md
+++ b/src/dalil/README.md
@@ -1,0 +1,6 @@
+# Dalil Module
+Dalil module uses require in the XML-like components. To use please refer to the code below,
+`<Dalil ayat='<ayat name>' soundFile={require('<ayat sound path>')} />`
+
+Real world usage can be found in the chapter1.js file. The snippets of the code can be found below,
+`<Dalil ayat='Testing' soundFile={require('./dalil-sound/test.mp3')} />`

--- a/src/dalil/dalil.js
+++ b/src/dalil/dalil.js
@@ -50,9 +50,7 @@ class Dalil extends Component {
       isMuted: false,
     };
 
-    await this.soundObject.loadAsync(
-      require("../contents/dalil-sound/" + this.props.soundFile)
-    );
+    await this.soundObject.loadAsync(this.props.soundFile);
     await this.soundObject.setStatusAsync(initialStatus);
 
     console.log("Done making : ", this.soundObject);


### PR DESCRIPTION
Dalil components error of using `+` in `require()` now has fixed with using different ways to do `require()`. By moving the require as a component variable in `prop`, the usage of `+` or any other variables is now fixed.

This PR should Closes #4 as it fixes the issue.